### PR TITLE
fix: add validation for file size and file limit + handle multiple fi…

### DIFF
--- a/resources/views/reportes/partials/comprobantes.blade.php
+++ b/resources/views/reportes/partials/comprobantes.blade.php
@@ -84,6 +84,7 @@
     const empty = document.getElementById('empty');
 
     let FILES = {};
+    let dataTransfer = new DataTransfer(); // CREAMOS un nuevo objeto DataTransfer para almacenar los archivos
 
     function addFile(target, file) {
         const objectURL = URL.createObjectURL(file);
@@ -113,12 +114,22 @@
     document.getElementById('button').onclick = () => hidden.click();
     hidden.onchange = (e) => {
         for (const file of e.target.files) {
-            const isImage = file.type.match('image.png|image.jpeg|image.jpg');
+            if (gallery.querySelectorAll('li:not(#empty)').length >= 5) { // Validamos si hay más de 5 archivos
+                noty('Solo se permiten 5 archivos', 'error');
+                return;
+            }
+            if (file.size > 10485760) { // Validamos el tamaño máximo de 10MB
+                noty('El tamaño máximo permitido es de 10MB', 'error');
+                return;
+            }
+            const isImage = file.type.match('image.png|image.jpeg|image.jpg'); // Validamos el tipo de archivo
             if (!isImage) {
                 noty('Solo se permiten imágenes en formato PNG, JPEG o JPG', 'error');
                 return;
             }
             addFile(gallery, file);
+            dataTransfer.items.add(file); // AÑADIMOS al DataTransfer
+            hidden.files = dataTransfer.files; // ACTUALIZAMOS el input con los archivos acumulados
         }
     };
 
@@ -159,6 +170,15 @@
             document.getElementById(ou).remove(ou);
             gallery.children.length === 1 && empty.classList.remove('hidden');
             delete FILES[ou];
+
+            // RECONSTRUIMOS el objeto DataTransfer sin el archivo eliminado
+            dataTransfer = new DataTransfer();
+            Object.values(FILES).forEach(file => dataTransfer.items.add(file));
+            hidden.files = dataTransfer.files;
+
+            if (Object.keys(FILES).length === 0) {
+                empty.classList.remove('hidden');
+            }
         }
     };
 </script>


### PR DESCRIPTION
This pull request includes several updates to the file upload functionality in `resources/views/reportes/partials/comprobantes.blade.php`. The changes introduce file validation and management improvements to enhance user experience and ensure compliance with file size and type restrictions.

File validation and management improvements:

* Added a new `DataTransfer` object to manage file uploads and ensure the input field is updated with the accumulated files.
* Implemented a check to limit the number of uploaded files to a maximum of 5, displaying an error notification if exceeded.
* Added a file size validation to restrict uploads to a maximum of 10MB, with an error notification for files exceeding this limit.
* Ensured that only images in PNG, JPEG, or JPG formats are accepted, with appropriate error notifications for invalid file types.
* Rebuilt the `DataTransfer` object when a file is removed to keep the input field synchronized with the remaining files.